### PR TITLE
Virtual destructor for AbstractMatrix

### DIFF
--- a/include/pacbio/consensus/AbstractMatrix.h
+++ b/include/pacbio/consensus/AbstractMatrix.h
@@ -57,6 +57,9 @@ public:
     virtual size_t UsedEntries() const = 0;
     virtual float UsedEntriesRatio() const = 0;
     virtual size_t AllocatedEntries() const = 0;  // an entry may be allocated but not used
+
+public:
+    virtual ~AbstractMatrix() {}
 };
 
 }  // namespace Consensus


### PR DESCRIPTION
If no one objects, this is good style and I should have caught it earlier, but it's impossible given the hundreds of compiler warnings we have at present...