### PR TITLE
Deduplicate the use of SNR in AddRead/GetTemplate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
  - Fix index errors in the Hirschberg aligner
+ - Added a cleaner interface for AddRead/GetTemplate
 
 ## [2.0.1]
 

--- a/include/pacbio/consensus/MultiMolecularIntegrator.h
+++ b/include/pacbio/consensus/MultiMolecularIntegrator.h
@@ -46,6 +46,7 @@
 #include <pacbio/exception/StateError.h>
 #include <pacbio/consensus/Mutation.h>
 #include <pacbio/data/State.h>
+#include <pacbio/data/Read.h>
 
 namespace PacBio {
 namespace Consensus {
@@ -66,8 +67,7 @@ public:
     PacBio::Data::State AddRead(const PacBio::Data::MappedRead& read);
 
 protected:
-    std::unique_ptr<AbstractTemplate> GetTemplate(const PacBio::Data::MappedRead& read, 
-                                                  const PacBio::Data::SNR& snr);
+    std::unique_ptr<AbstractTemplate> GetTemplate(const PacBio::Data::MappedRead& read);
 
     std::string fwdTpl_;
     std::string revTpl_;

--- a/src/ModelFactory.cpp
+++ b/src/ModelFactory.cpp
@@ -85,6 +85,11 @@ std::unique_ptr<ModelConfig> ModelFactory::Create(const std::string& name, const
     return it->second->Create(snr);
 }
 
+std::unique_ptr<ModelConfig> ModelFactory::Create(const PacBio::Data::Read& read)
+{
+    return Create(read.Model, read.SignalToNoise);
+}
+
 bool ModelFactory::Register(const std::string& name, std::unique_ptr<ModelCreator>&& ctor)
 {
     return CreatorTable()

--- a/src/ModelFactory.h
+++ b/src/ModelFactory.h
@@ -44,6 +44,7 @@
 
 #include <boost/optional.hpp>
 
+#include <pacbio/data/Read.h>
 #include <pacbio/exception/ModelError.h>
 
 namespace PacBio {
@@ -79,6 +80,7 @@ class ModelFactory
 {
 public:
     static std::unique_ptr<ModelConfig> Create(const std::string& name, const SNR&);
+    static std::unique_ptr<ModelConfig> Create(const PacBio::Data::Read& read);
     static bool Register(const std::string& name, std::unique_ptr<ModelCreator>&& ctor);
     static boost::optional<std::string> Resolve(const std::string& name);
     static std::set<std::string> SupportedModels();


### PR DESCRIPTION
Duplication of SNR in FinePhaser in LAA lead me down a rabbit hole to this.